### PR TITLE
Add level option

### DIFF
--- a/lib/clhi.ex
+++ b/lib/clhi.ex
@@ -9,19 +9,19 @@ defmodule Clhi do
       number_options: false,
       hide_options: false,
       stringyify_options: true,
-      cast_answer: false,
-      default: nil
+      cast_answer: opts[:boolean_options] == true,
+      default: nil,
+      level: :info
     ]
 
-    opts = override_defaults(default_opts, opts)
+    %{level: level} = opts = override_defaults(default_opts, opts)
 
     gets_msg = build_gets_msg(opts)
-
-    info(question)
+    puts(question, opts)
 
     _ =
       unless opts.hide_options or opts.boolean_options do
-        print_options(options, Map.to_list(opts))
+        print_options(options, opts)
       end
 
     parsed_options =
@@ -29,7 +29,7 @@ defmodule Clhi do
         do: Enum.map(options, &to_string/1),
         else: options
 
-    with {:ok, answer} <- parse_choice(gets(msg: gets_msg), parsed_options, opts),
+    with {:ok, answer} <- parse_choice(gets(msg: gets_msg, level: level), parsed_options, opts),
          {:ok, parsed_answer} <- parse_answer(answer, opts) do
       parsed_answer
     else
@@ -58,10 +58,6 @@ defmodule Clhi do
   defp parse_choice(choice, options, opts)
 
   defp parse_choice("", _, %{default: default}) when not is_nil(default), do: {:ok, "#{default}"}
-
-  defp parse_choice("y", _, %{boolean_options: true}), do: {:ok, true}
-
-  defp parse_choice("n", _, %{boolean_options: true}), do: {:ok, false}
 
   defp parse_choice(choice, options, %{number_options: true}) do
     options_length = length(options)
@@ -92,6 +88,10 @@ defmodule Clhi do
   defp parse_answer(answer, %{cast_answer: cast_answer}) when is_function(cast_answer),
     do: cast_answer.(answer)
 
+  defp parse_answer("y", %{cast_answer: true, boolean_options: true}), do: {:ok, true}
+
+  defp parse_answer("n", %{cast_answer: true, boolean_options: true}), do: {:ok, false}
+
   defp parse_answer(answer, %{cast_answer: :atom}), do: {:ok, String.to_existing_atom(answer)}
 
   defp parse_answer(answer, %{cast_answer: :date}), do: Date.from_iso8601(answer)
@@ -101,28 +101,35 @@ defmodule Clhi do
       number_options: true
     ]
 
-    opts = override_defaults(default_opts, opts)
+    %{level: level, number_options: number_options} = override_defaults(default_opts, opts)
 
     for {option, index} <- Enum.with_index(options) do
       formatted_option =
-        if opts.number_options,
+        if number_options,
           do: "#{index + 1}. #{option}",
           else: "* #{option}"
 
-      IO.puts(formatted_option)
+      puts(formatted_option, level: level, newline: false)
     end
   end
 
-  def info(msg), do: IO.puts(["\n", msg, IO.ANSI.reset()])
+  def info(msg), do: puts(msg, level: :info)
 
-  def warn(msg), do: info([IO.ANSI.yellow(), msg])
+  def warn(msg), do: puts(msg, level: :warn)
 
-  def error(msg), do: info([IO.ANSI.red(), msg])
+  def error(msg), do: puts(msg, level: :error)
+
+  def puts(msg, opts) do
+    default_opts = [newline: true, level: :info]
+    opts = override_defaults(default_opts, opts)
+    IO.puts([opts.newline && "\n", level_to_color(opts.level), msg, IO.ANSI.reset()])
+  end
 
   def gets(opts) do
     default_opts = [
       msg: "> ",
-      trim: true
+      trim: true,
+      level: :info
     ]
 
     opts = override_defaults(default_opts, opts)
@@ -130,7 +137,7 @@ defmodule Clhi do
     IO.puts("")
 
     ret =
-      opts.msg
+      [level_to_color(opts.level), opts.msg, IO.ANSI.reset()]
       |> IO.gets()
       |> String.slice(0..-2)
 
@@ -146,4 +153,10 @@ defmodule Clhi do
     |> Enum.into(%{})
     |> Map.merge(opt_map)
   end
+
+  defp level_to_color(:info), do: []
+
+  defp level_to_color(:warn), do: [IO.ANSI.yellow()]
+
+  defp level_to_color(:error), do: [IO.ANSI.red()]
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Clhi.MixProject do
   def project do
     [
       app: :clhi,
-      version: "0.1.0",
+      version: "0.2.0",
       elixir: "~> 1.6",
       start_permanent: Mix.env() == :prod,
       deps: [{:ex_doc, "~> 0.0", only: :dev}],


### PR DESCRIPTION
Why
---

* So that prompts can be printed in colors other than white (info)

How
---

* Add puts/2
* ask/3, gets/1, and puts/2 support `:level` option